### PR TITLE
Fix sampling impact parameter

### DIFF
--- a/src/collider.cxx
+++ b/src/collider.cxx
@@ -108,7 +108,7 @@ std::tuple<double, int> Collider::sample_collision() {
 
   do {
     // Sample b from P(b)db = 2*pi*b.
-    b = bmin_ + (bmax_ - bmin_) * std::sqrt(random::canonical<double>());
+    b = std::sqrt(bmin_ * bmin_ + (bmax_ * bmax_ - bmin_ * bmin_) * random::canonical<double>());
 
     // Offset each nucleus depending on the asymmetry parameter (see header).
     nucleusA_->sample_nucleons(asymmetry_ * b);


### PR DESCRIPTION
For getting the proper fraction of the cross section when the requested minimum value of the impact parameter is not zero